### PR TITLE
Unify of REST API service to work with asmt entities

### DIFF
--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -260,7 +260,7 @@ class AuditsFactory(EntitiesFactory):
     if actual_count_all_audits == audit.id:
       return [
           cls.update_obj_attrs_values(
-              obj=copy.deepcopy(audit),
+              obj=copy.deepcopy(audit), type=cls.obj_audit.lower(),
               title=audit.title + " - copy " + str(num), id=audit.id + num,
               href=re.sub("\d+$", str(audit.id + num), audit.href),
               url=re.sub("\d+$", str(audit.id + num), audit.url),

--- a/test/selenium/src/lib/service/rest/template/assessment.json
+++ b/test/selenium/src/lib/service/rest/template/assessment.json
@@ -7,7 +7,7 @@
   "validate_creator": true,
   "validate_assessor": true,
   "title": null,
-  "object": null,
+  "object": {},
   "audit": null,
   "description": "",
   "send_by_default": false,

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -183,9 +183,8 @@ def new_asmt_rest(new_audit_rest):
   (lib.entities.entity.Assessment, lib.entities.entity.Audit,
   lib.entities.entity.Program)
   """
-  yield (AssessmentsService().create(
-      count=1, obj=new_audit_rest[1],
-      audit=new_audit_rest[0])[0], new_audit_rest[0], new_audit_rest[1])
+  yield (AssessmentsService().create(count=1, audit=new_audit_rest[0])[0],
+         new_audit_rest[0], new_audit_rest[1])
 
 
 @pytest.yield_fixture(scope="function")


### PR DESCRIPTION
This PR unify of REST API service to work with asmt entities and to fix next failed selenium tests:

> src.tests.test_audit_page.TestAuditPage.test_cloned_audit_contains_new_attrs
> src.tests.test_audit_page.TestAuditPage.test_non_clonable_objs_donot_move_to_cloned_audit
> src.tests.test_audit_page.TestAuditPage.test_clonable_audit_related_objs_move_to_cloned_audit
> src.tests.test_audit_page.TestAuditPage.test_clonable_not_audit_related_objs_move_to_cloned_audit
